### PR TITLE
scp bug fix & pango build error

### DIFF
--- a/apps/glibc/Makefile
+++ b/apps/glibc/Makefile
@@ -8,6 +8,11 @@ CROSS_USER_LFLAGS=
 GLIBCDIR=$(TOPDIR)/gnu/glibc/$(GLIBC)
 
 ##
+## "scp" command support ...
+##
+LIBSSP_SO=libssp.so
+
+##
 ## LOCALE installation flag : It will take very long time. 
 ##
 LOCALE_FLAG=0
@@ -40,7 +45,11 @@ install:
 			make install_root=`pwd`/../target install;  \
 			[ "$(LOCALE_FLAG)" = "0" ] || make install_root=`pwd`/../target localedata/install-locales; \
 			cd ../target; \
-			tar zcvf ../$(GLIBC_TARGET_FILE) * > /dev/null ) \
+			[ -h lib/$(LIBSSP_SO) ] || (    \
+				cd lib                ;     \
+				ln -s /lib64/$(LIBSSP_SO).0 $(LIBSSP_SO).0 ;  \
+				ln -s $(LIBSSP_SO).0 $(LIBSSP_SO) ) ;         \
+			tar zcvf ../$(GLIBC_TARGET_FILE) * > /dev/null )  \
 	)
 
 ##

--- a/exts/openssh/Makefile
+++ b/exts/openssh/Makefile
@@ -5,11 +5,6 @@ include $(TOPDIR)/scripts/extenv.mk
 
 CROSS_USER_CFLAGS += -DMB_LEN_MAX=16
 
-##
-## To support "scp" ...
-##
-EXTLIB=libssp.so
-
 MICB_CONFIGURE_OPTS += --disable-strip --with-pam
 
 MICB_CONFIGURE_RUNENV += \
@@ -32,11 +27,7 @@ all install uninstall clean:
 	@[ "$@" != "install" ] || ( \
 		[ ! -d $(BUILDDIR)/$(DIR) ] || ( \
                 cd $(BUILDDIR)/$(DIR); \
-				make $(MICB_CONFIGURE_MAKEOPTS) install-mbsp ) && \
-		[ -h $(destination)/lib/$(EXTLIB) ] || (    \
-			cd $(destination)/lib                ;  \
-			ln -s /lib64/$(EXTLIB).0 $(EXTLIB).0 ;  \
-			ln -s $(EXTLIB).0 $(EXTLIB) )           \
+				make $(MICB_CONFIGURE_MAKEOPTS) install-mbsp ) \
     )
 
 

--- a/uix/pango/Makefile
+++ b/uix/pango/Makefile
@@ -1,6 +1,5 @@
-PANGOVER=1.50
-DIR=pango-$(PANGOVER).11
-LOC=https://download.gnome.org/sources/pango/$(PANGOVER)
+DIR=pango
+LOC=https://github.com/GNOME
 
 include $(TOPDIR)/scripts/uixenv.mk
 
@@ -14,7 +13,7 @@ CROSS_USER_LFLAGS += -lglapi
 
 prepare:
 	@[ -d $(BUILDDIR)/$(DIR) ] || mkdir -p $(BUILDDIR)/$(DIR)
-	@[ -f $(MICBSRC)/$(DIR).tar.xz ] || ( $(UNCOMPRESS) $(LOC)/$(DIR).tar.xz ; $(MICB_PATCH) )
+	@[ -d $(MICBSRC)/$(DIR)  ] || ( $(UNCOMPRESS) $(LOC)/$(DIR).git ; $(MICB_PATCH) )
 	@[ ! -d $(MICBSRC)/$(DIR) ] || $(MICB_MESON_CROSSBUILD_FILE)
 	@cd $(BUILDDIR)/$(DIR); \
 		$(MICB_MESON_CMD) $(MICB_MESON_OPTS)


### PR DESCRIPTION
libssp.so* should be placed under /lib and /lib64 for scp connection. Restoring sources from openssh because it cannot make difference instead apps/glibc is tailored to support this. Pango source access is changed from wget to git. Github.com is more stable.