### PR TITLE
Disabling CONFIG_ARM64_TLB_RANGE

### DIFF
--- a/boards/rpi3/kernel/patch/patch-rpi-5.15.y
+++ b/boards/rpi3/kernel/patch/patch-rpi-5.15.y
@@ -1,6 +1,18 @@
-diff -uNr linux-rpi-5.15.y-orig/arch/arm64/Makefile linux-rpi-5.15.y/arch/arm64/Makefile
---- linux-rpi-5.15.y-orig/arch/arm64/Makefile	2023-02-08 08:47:50.000000000 -0800
-+++ linux-rpi-5.15.y/arch/arm64/Makefile	2023-04-06 20:13:02.619304932 -0700
+diff -uNr linux-rpi-5.15.y-original/arch/arm64/Kconfig linux-rpi-5.15.y/arch/arm64/Kconfig
+--- linux-rpi-5.15.y-original/arch/arm64/Kconfig	2023-02-08 08:47:50.000000000 -0800
++++ linux-rpi-5.15.y/arch/arm64/Kconfig	2023-05-10 12:42:12.999165551 -0700
+@@ -1630,7 +1630,7 @@
+ 
+ config ARM64_TLB_RANGE
+ 	bool "Enable support for tlbi range feature"
+-	default y
++	default n
+ 	depends on AS_HAS_ARMV8_4
+ 	help
+ 	  ARMv8.4-TLBI provides TLBI invalidation instruction that apply to a
+diff -uNr linux-rpi-5.15.y-original/arch/arm64/Makefile linux-rpi-5.15.y/arch/arm64/Makefile
+--- linux-rpi-5.15.y-original/arch/arm64/Makefile	2023-02-08 08:47:50.000000000 -0800
++++ linux-rpi-5.15.y/arch/arm64/Makefile	2023-05-10 12:41:51.158986859 -0700
 @@ -93,6 +93,9 @@
  asm-arch := armv8.5-a
  endif
@@ -11,9 +23,9 @@ diff -uNr linux-rpi-5.15.y-orig/arch/arm64/Makefile linux-rpi-5.15.y/arch/arm64/
  ifdef asm-arch
  KBUILD_CFLAGS	+= -Wa,-march=$(asm-arch) \
  		   -DARM64_ASM_ARCH='"$(asm-arch)"'
-diff -uNr linux-rpi-5.15.y-orig/drivers/base/firmware_loader/main.c linux-rpi-5.15.y/drivers/base/firmware_loader/main.c
---- linux-rpi-5.15.y-orig/drivers/base/firmware_loader/main.c	2023-02-08 08:47:50.000000000 -0800
-+++ linux-rpi-5.15.y/drivers/base/firmware_loader/main.c	2023-04-06 20:11:50.483011797 -0700
+diff -uNr linux-rpi-5.15.y-original/drivers/base/firmware_loader/main.c linux-rpi-5.15.y/drivers/base/firmware_loader/main.c
+--- linux-rpi-5.15.y-original/drivers/base/firmware_loader/main.c	2023-02-08 08:47:50.000000000 -0800
++++ linux-rpi-5.15.y/drivers/base/firmware_loader/main.c	2023-05-10 12:41:51.162986892 -0700
 @@ -471,6 +471,9 @@
  	"/lib/firmware/updates",
  	"/lib/firmware/" UTS_RELEASE,
@@ -24,9 +36,9 @@ diff -uNr linux-rpi-5.15.y-orig/drivers/base/firmware_loader/main.c linux-rpi-5.
  };
  
  /*
-diff -uNr linux-rpi-5.15.y-orig/Makefile linux-rpi-5.15.y/Makefile
---- linux-rpi-5.15.y-orig/Makefile	2023-02-08 08:47:50.000000000 -0800
-+++ linux-rpi-5.15.y/Makefile	2023-04-06 20:11:50.483011797 -0700
+diff -uNr linux-rpi-5.15.y-original/Makefile linux-rpi-5.15.y/Makefile
+--- linux-rpi-5.15.y-original/Makefile	2023-02-08 08:47:50.000000000 -0800
++++ linux-rpi-5.15.y/Makefile	2023-05-10 12:41:51.162986892 -0700
 @@ -433,7 +433,7 @@
  HOSTPKG_CONFIG	= pkg-config
  
@@ -45,9 +57,9 @@ diff -uNr linux-rpi-5.15.y-orig/Makefile linux-rpi-5.15.y/Makefile
  KBUILD_CPPFLAGS := -D__KERNEL__
  KBUILD_AFLAGS_KERNEL :=
  KBUILD_CFLAGS_KERNEL :=
-diff -uNr linux-rpi-5.15.y-orig/net/wireless/sme.c linux-rpi-5.15.y/net/wireless/sme.c
---- linux-rpi-5.15.y-orig/net/wireless/sme.c	2023-02-08 08:47:50.000000000 -0800
-+++ linux-rpi-5.15.y/net/wireless/sme.c	2023-04-06 21:29:41.884042817 -0700
+diff -uNr linux-rpi-5.15.y-original/net/wireless/sme.c linux-rpi-5.15.y/net/wireless/sme.c
+--- linux-rpi-5.15.y-original/net/wireless/sme.c	2023-02-08 08:47:50.000000000 -0800
++++ linux-rpi-5.15.y/net/wireless/sme.c	2023-05-10 12:41:51.162986892 -0700
 @@ -753,7 +753,9 @@
  		return;
  	}


### PR DESCRIPTION
ARM64_TLB_RANGE requires specific instruction and it does not match with binutlis in current use. 